### PR TITLE
Fix Jupyter typo

### DIFF
--- a/docs/jupyter.md
+++ b/docs/jupyter.md
@@ -1,4 +1,4 @@
-Use `MapWidget` in your [Juyper](https://jupyter.org/) Notebook:
+Use `MapWidget` in your [Jupyter](https://jupyter.org/) Notebook:
 
 ```python
 import ipywidgets as widgets


### PR DESCRIPTION
Thanks for this package!

Just spotted a minor typo while looking at the docs:

![image](https://github.com/user-attachments/assets/f76d3905-9087-4a8b-b0a0-4c26c5fe485d)
