### PR TITLE
Shiny module

### DIFF
--- a/maplibre/mapcontext.py
+++ b/maplibre/mapcontext.py
@@ -18,8 +18,8 @@ class MapContext(Map):
     """
 
     def __init__(self, id: str, session: Session = None) -> None:
-        self.id = id
         self._session = require_active_session(session)
+        self.id = id if self._session.ns == "" else f"{self._session.ns}-{id}"
         self.map_options = {}
         self._message_queue = []
 

--- a/maplibre/shiny/mapcontext.py
+++ b/maplibre/shiny/mapcontext.py
@@ -26,8 +26,8 @@ class MapContext(Map):
     """
 
     def __init__(self, id: str, session: Session = None) -> None:
-        self.id = id
         self._session = require_active_session(session)
+        self.id = id if self._session.ns == "" else f"{self._session.ns}-{id}"
         self.map_options = dict()
         self._message_queue = list()
 


### PR DESCRIPTION
Closes #142 : Permits to use py-maplibre in shiny modules by correctly resolving the `id` given to the map component. 